### PR TITLE
Add support for delayed exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 vendor/
+
+.envrc

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:4c6e252333978a28daf21528c10e51020393dad494adef97e4c9db78c9e8350e"
+  digest = "1:cd6cc5fd9292f991aff941df146e952f11630748cba7283a55bc401637eb7661"
   name = "github.com/streadway/amqp"
   packages = ["."]
   pruneopts = ""
-  revision = "ff791c2d22d3f1588b4e2cc71a9fba5e1da90654"
+  revision = "1c71cc93ed716f9a6f4c2ae8955c25f9176d9f19"
+  version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,5 +22,5 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "v1.0.0"
   name = "github.com/streadway/amqp"

--- a/_examples/delay_exchange.go
+++ b/_examples/delay_exchange.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"time"
+
 	"github.com/ofpiyush/hedwig-go"
 	"github.com/streadway/amqp"
 )
 
-// this is a brief example which explains how to setup a delay exchange queue
+// this is a short example which explains how to setup a delay exchange queue
 // https://www.rabbitmq.com/blog/2015/04/16/scheduling-messages-with-rabbitmq/
 func getDelayExchangeSettings() *hedwig.Settings {
 	// get the preconfigured default exchange
@@ -16,5 +22,52 @@ func getDelayExchangeSettings() *hedwig.Settings {
 	s.ExchangeArgs = amqp.Table{
 		hedwig.DelayedExchangeArgKey: amqp.ExchangeTopic,
 	}
+	// set up the exchange name and auth
+	s.Exchange = "hedwig-delayed"
+	s.Host = os.Getenv("RABBITMQ_HOST")
+	s.Username = os.Getenv("RABBITMQ_USER")
+	s.Password = os.Getenv("RABBITMQ_PASS")
 	return s
+}
+
+func main() {
+	settings := getDelayExchangeSettings()
+	h := hedwig.New(settings)
+
+	// set up the queue and bindings
+	publishKey := "delayKey"
+	binding := fmt.Sprintf("%s.*", publishKey)
+	h.AddQueue(hedwig.DefaultQueueSetting(messageHandler, binding), "")
+
+	// publisher
+	go func() {
+		for i := 0; i < 5; i++ {
+			delay := time.Duration(i*10) * time.Second
+			msg := fmt.Sprintf("I am: %d", int(delay.Seconds()))
+			log.Println("publishing: ", msg)
+			err := h.PublishWithDelay(fmt.Sprintf("%s.0", publishKey), []byte(msg), delay)
+			if err != nil {
+				log.Println("publish failed:", err)
+			}
+		}
+	}()
+
+	err := h.Consume()
+	log.Println(err)
+	if err != nil {
+		log.Fatalln("consume failed: ", err)
+	}
+
+}
+
+func messageHandler(delChan <-chan amqp.Delivery, wg *sync.WaitGroup) {
+	defer wg.Done()
+	var err error
+	for msg := range delChan {
+		log.Println("\tBody: ", string(msg.Body), " headers: ", msg.Headers)
+		err = msg.Ack(false)
+		if err != nil {
+			log.Println("ack error:", err)
+		}
+	}
 }

--- a/_examples/delay_exchange.go
+++ b/_examples/delay_exchange.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/ofpiyush/hedwig-go"
+	"github.com/streadway/amqp"
+)
+
+// this is a brief example which explains how to setup a delay exchange queue
+// https://www.rabbitmq.com/blog/2015/04/16/scheduling-messages-with-rabbitmq/
+func getDelayExchangeSettings() *hedwig.Settings {
+	// get the preconfigured default exchange
+	s := hedwig.DefaultSettings()
+	// setup the exchange type to delay
+	s.ExchangeType = hedwig.ExchangeTypeDelayed
+	// set up the actual exchange behaviour like `direct`, `topic` etc
+	s.ExchangeArgs = amqp.Table{
+		hedwig.DelayedExchangeArgKey: amqp.ExchangeTopic,
+	}
+	return s
+}

--- a/_examples/delay_exchange.go
+++ b/_examples/delay_exchange.go
@@ -44,7 +44,7 @@ func main() {
 		for i := 0; i < 5; i++ {
 			delay := time.Duration(i*10) * time.Second
 			msg := fmt.Sprintf("I am: %d", int(delay.Seconds()))
-			log.Println("publishing: ", msg)
+			log.Println("\tPublishing: ", msg)
 			err := h.PublishWithDelay(fmt.Sprintf("%s.0", publishKey), []byte(msg), delay)
 			if err != nil {
 				log.Println("publish failed:", err)

--- a/hedwig.go
+++ b/hedwig.go
@@ -20,7 +20,7 @@ type Callback func(<-chan amqp.Delivery, *sync.WaitGroup)
 func DefaultSettings() *Settings {
 	return &Settings{
 		Exchange:          "hedwig",
-		ExchangeType:      "topic",
+		ExchangeType:      amqp.ExchangeTopic,
 		HeartBeatInterval: 5 * time.Second,
 		SocketTimeout:     1 * time.Second,
 		Host:              "localhost",

--- a/hedwig.go
+++ b/hedwig.go
@@ -21,6 +21,7 @@ func DefaultSettings() *Settings {
 	return &Settings{
 		Exchange:          "hedwig",
 		ExchangeType:      amqp.ExchangeTopic,
+		ExchangeArgs:      nil,
 		HeartBeatInterval: 5 * time.Second,
 		SocketTimeout:     1 * time.Second,
 		Host:              "localhost",
@@ -61,6 +62,7 @@ type ConsumerSetting struct {
 type Settings struct {
 	Exchange          string
 	ExchangeType      string
+	ExchangeArgs      amqp.Table
 	HeartBeatInterval time.Duration
 	SocketTimeout     time.Duration
 	Host              string
@@ -207,7 +209,7 @@ func (h *Hedwig) getChannel(name string) (ch *amqp.Channel, err error) {
 	}
 	err = h.channels[name].ExchangeDeclare(
 		h.Settings.Exchange, h.Settings.ExchangeType, true,
-		false, false, false, nil)
+		false, false, false, h.Settings.ExchangeArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/hedwig.go
+++ b/hedwig.go
@@ -121,7 +121,7 @@ func (h *Hedwig) PublishWithDelay(key string, body []byte, delay time.Duration) 
 	return h.PublishWithHeaders(key, body, headers)
 }
 
-func (h *Hedwig) PublishWithHeaders(key string, body []byte, headers amqp.Table) (err error) {
+func (h *Hedwig) PublishWithHeaders(key string, body []byte, headers map[string]interface{}) (err error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/types.go
+++ b/types.go
@@ -1,6 +1,9 @@
 package hedwig
 
-
 const (
-	ExchangeDelayed  = "x-delayed-message"
+	// For exchanges which use RMQ delay plugin, following type should be used as ExchangeType
+	ExchangeTypeDelayed = "x-delayed-message"
+	// Delayed Type Exchanges also need an extra arg with following key with the value set to actual ExchangeType
+	// like `direct`, `topic` etc
+	DelayedExchangeArgKey = "x-delayed-type"
 )

--- a/types.go
+++ b/types.go
@@ -6,4 +6,7 @@ const (
 	// Delayed Type Exchanges also need an extra arg with following key with the value set to actual ExchangeType
 	// like `direct`, `topic` etc
 	DelayedExchangeArgKey = "x-delayed-type"
+	// Following header should be used when you are publishing to an Delay exchange. The header value will be
+	// delay in milliseconds
+	DelayHeader = "x-delay"
 )

--- a/types.go
+++ b/types.go
@@ -1,0 +1,6 @@
+package hedwig
+
+
+const (
+	ExchangeDelayed  = "x-delayed-message"
+)


### PR DESCRIPTION
This PR enables Hedwig to work with delayed exchanges as shown [here](https://www.rabbitmq.com/blog/2015/04/16/scheduling-messages-with-rabbitmq/)

to run the example, you need to have [this plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) installed. 

```
$ go run delay_exchange.go

2020/05/07 17:34:41 	Publishing:  I am: 0
2020/05/07 17:34:41 	Publishing:  I am: 10
2020/05/07 17:34:41 	Publishing:  I am: 20
2020/05/07 17:34:41 	Publishing:  I am: 30
2020/05/07 17:34:41 	Publishing:  I am: 40
2020/05/07 17:34:41 	Body:  I am: 0  headers:  map[x-delay:0]
2020/05/07 17:34:51 	Body:  I am: 10  headers:  map[x-delay:10000]
2020/05/07 17:35:01 	Body:  I am: 20  headers:  map[x-delay:20000]
2020/05/07 17:35:11 	Body:  I am: 30  headers:  map[x-delay:30000]
2020/05/07 17:35:21 	Body:  I am: 40  headers:  map[x-delay:40000]
```